### PR TITLE
Clear option included

### DIFF
--- a/home.html
+++ b/home.html
@@ -67,6 +67,7 @@
                 <button onclick="apply('table')" title="Table">⚏</button>
             </div>
             <div>
+                <span class="clear" id="ClearText" onclick="clearTextArea()">Clear</span>
                 <span>
                     <label class="file" for="file">Open<input id="file" type="file" accept=".txt,.text,.md,.markdown,.markdn,.mdown,.htm,.html,.svg" onchange="openFile(event)" /></label>
                 </span>

--- a/main.css
+++ b/main.css
@@ -93,7 +93,7 @@ footer,header{
 .tools span{
     padding:0 8px
 }
-.file,button{
+.file,button,.clear{
     padding:8px 16px;
     background-color:transparent;
     color:var(--afont-color);

--- a/main.js
+++ b/main.js
@@ -124,6 +124,10 @@ const Preview = {
             this.buffer.innerHTML = `<p>${marked(this.textarea.value)}</p>`;
         }
         this.Update();
+    },
+    ClearPreview() {
+        this.preview.innerHTML = '';
+        this.buffer.innerHTML = '';
     }
 };
 Preview.callback = MathJax.Callback(["CreatePreview", Preview]);
@@ -339,3 +343,9 @@ function DownloadFile() {
     OpenCloseSaveFile();
     document.getElementById("DownloadFileForm").reset;
 }
+
+/*Clears the TextArea along with the associated markdown*/
+const clearTextArea = () => {
+    document.getElementById("getm").value = '';
+    Preview.ClearPreview();
+};

--- a/main.js
+++ b/main.js
@@ -128,6 +128,8 @@ const Preview = {
     ClearPreview() {
         this.preview.innerHTML = '';
         this.buffer.innerHTML = '';
+        this.wordcount.innerHTML = '';
+        this.charcount.innerHTML = '';
     }
 };
 Preview.callback = MathJax.Callback(["CreatePreview", Preview]);

--- a/main.js
+++ b/main.js
@@ -128,8 +128,9 @@ const Preview = {
     ClearPreview() {
         this.preview.innerHTML = '';
         this.buffer.innerHTML = '';
-        this.wordcount.innerHTML = '';
-        this.charcount.innerHTML = '';
+        this.wordcount.innerHTML = pluralize(0, "Word");
+        this.charcount.innerHTML = pluralize(0, "Char");
+        updateLineNoColNo();
     }
 };
 Preview.callback = MathJax.Callback(["CreatePreview", Preview]);


### PR DESCRIPTION
# Purpose of Pull Request

- Inclusion of a `Clear` option in the navigation bar section along with `Open` and `Save` . 
- This option allows users to clear the whole textarea along with the markdown associated with the text which will save time to re-write the entire markdown from scratch. 

** Update **
- Along with the textarea and markdown section, The footer values: `Line`, `Col`, `Chars`, `Words` will be reset to initial values.

## Snaps to view the use of Clear option
1. Before Clear:
   ![before-clear](https://user-images.githubusercontent.com/52874416/133747804-43820331-24ef-4851-9ce0-a2a6675febe0.PNG)
2. After Clear:
  ![After-clear](https://user-images.githubusercontent.com/52874416/133747822-05faef74-59a1-40bc-8cf1-2d30e6fb9d90.PNG)