### PR TITLE
Fix Typo

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -38,5 +38,5 @@
 	"display": "standalone",
 	"orientation": "any",
 	"theme_color": "#FFFFFF",
-	"background_color": "#FFFFF"
+	"background_color": "#FFFFFF"
 }


### PR DESCRIPTION
"background_color" attribute was set to "#FFFFF", therefore causing an error.