### PR TITLE
Update marked.js syntax

### DIFF
--- a/home.html
+++ b/home.html
@@ -25,7 +25,7 @@
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@latest/build/styles/dracula.min.css" />
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono:400,700&display=swap" />
         <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML&delayStartupUntil=configured"></script>
-        <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/marked@4.0.6/marked.min.js"></script>
         <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@latest/build/highlight.min.js"></script>
         <script src="https://cdn.jsdelivr.net/gh/asvd/syncscroll/syncscroll.min.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/dompurify@2.3/dist/purify.min.js"></script>

--- a/main.js
+++ b/main.js
@@ -89,7 +89,7 @@ const Preview = {
         this.mjRunning = false;
         text = this.buffer.innerHTML;
         text = this.PartialDescape(text);
-        this.buffer.innerHTML = DOMPurify.sanitize(marked(text));   // Sanitize output HTML
+        this.buffer.innerHTML = DOMPurify.sanitize(marked.parse(text));   // Sanitize output HTML
         document.querySelectorAll("code").forEach((block) => {
             hljs.highlightBlock(block);
         });
@@ -120,8 +120,8 @@ const Preview = {
         keyCode
     }) {
         if (keyCode < 16 || keyCode > 47) {
-            this.preview.innerHTML = `<p>${marked(this.textarea.value)}</p>`;
-            this.buffer.innerHTML = `<p>${marked(this.textarea.value)}</p>`;
+            this.preview.innerHTML = `<p>${marked.parse(this.textarea.value)}</p>`;
+            this.buffer.innerHTML = `<p>${marked.parse(this.textarea.value)}</p>`;
         }
         this.Update();
     },


### PR DESCRIPTION
[Fixes #29 ]

The `marked.js` syntax changed to 
```js
marked.parse('Markdown content')
```

In addition to changing this, I specified the marked.js version number to `4.0.6` (latest) in order to prevent this issue from happening again.