### PR TITLE
#enhancement: indent content when 'tab' key pressed

### DIFF
--- a/main.js
+++ b/main.js
@@ -407,3 +407,16 @@ scratchpad.addEventListener("keyup", event => {
     localStorage.setItem("notes", event.target.value)
   }, 1000)
 })
+
+/* Tab key to indent content with space */
+document.getElementById("getm").addEventListener("keydown",function(e){
+    if(e.key=="Tab"){
+        e.preventDefault();
+        let start=this.selectionStart;
+        let end=this.selectionEnd;
+
+        this.value=this.value.substring(0,start)+"\t"+this.value.substring(end);
+        this.selectionStart=this.selectionEnd=start+1;
+        console.log("Tab Key was clicked and space is apended");
+    }
+});


### PR DESCRIPTION
**Link to the issue**

Fixes #   indent text when click 'Tab'

**Describe the pull request**

Creating an eventListener to prevent the default tab action then apply a new Action which is adding some space 

